### PR TITLE
fix: NPM publishジョブがバージョン変更時のみ実行されるよう修正

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
 
   publish:
     needs: check-version
-    # if: needs.check-version.outputs.should-publish == 'true'
+    if: needs.check-version.outputs.should-publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 概要
release.yamlのpublishジョブがバージョン変更をチェックせずに実行される問題を修正しました。

## 変更内容
- `if: needs.check-version.outputs.should-publish == 'true'` のコメントアウトを解除
- バージョンが変更された場合のみpublishジョブが実行されるように修正

## 動作確認
- [ ] GitHub Actionsでバージョンが変更されていない場合、publishジョブがスキップされることを確認
- [ ] バージョンが変更された場合、publishジョブが正常に実行されることを確認

## 影響範囲
GitHub Actionsのrelease workflowのみ