### PR TITLE
fix: Claude Code hooksの設定を改善

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,41 @@
 					},
 					{
 						"type": "command",
-						"command": "bunx tsc"
+						"command": "bun run typecheck"
+					}
+				]
+			},
+			{
+				"matcher": "MultiEdit(*.ts)",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run format"
+					},
+					{
+						"type": "command",
+						"command": "bun run lint"
+					},
+					{
+						"type": "command",
+						"command": "bun run typecheck"
+					}
+				]
+			},
+			{
+				"matcher": "Write(*.ts)",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run format"
+					},
+					{
+						"type": "command",
+						"command": "bun run lint"
+					},
+					{
+						"type": "command",
+						"command": "bun run typecheck"
 					}
 				]
 			}


### PR DESCRIPTION
## 概要
Claude Code hooksの設定を改善し、TypeScriptファイル編集時の開発体験を向上させました。

## 変更内容
- `bunx tsc`コマンドを`bun run typecheck`に変更し、package.jsonのスクリプトとの一貫性を向上
- MultiEditツール使用時のhook設定を追加
- Writeツール使用時のhook設定を追加

## 影響範囲
- Claude Codeでの開発時のみ影響
- TypeScriptファイル編集時に自動でformat、lint、typecheckが実行される

## テスト
- [x] Edit、MultiEdit、Writeツールそれぞれでhookが正常に動作することを確認
- [x] bun run format、lint、typecheckコマンドが正常に実行されることを確認