### PR TITLE
ci: Add code quality checks to CI pipeline

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,29 +1,26 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(bun run lint)",
-      "Bash(bun run format)"
-    ]
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit(*.ts)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bun run format"
-          },
-          {
-            "type": "command",
-            "command": "bun run lint"
-          },
-          {
-            "type": "command",
-            "command": "bunx tsc"
-          }
-        ]
-      }
-    ]
-  }
+	"permissions": {
+		"allow": ["Bash(bun run lint)", "Bash(bun run format)"]
+	},
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Edit(*.ts)",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bun run format"
+					},
+					{
+						"type": "command",
+						"command": "bun run lint"
+					},
+					{
+						"type": "command",
+						"command": "bunx tsc"
+					}
+				]
+			}
+		]
+	}
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,23 +1,29 @@
 {
-	"hooks": {
-		"PostToolUse": [
-			{
-				"matcher": "Edit(*.ts)",
-				"hooks": [
-					{
-						"type": "command",
-						"command": "bun run format"
-					},
-					{
-						"type": "command",
-						"command": "bun run lint"
-					},
-					{
-						"type": "command",
-						"command": "bunx tsc"
-					}
-				]
-			}
-		]
-	}
+  "permissions": {
+    "allow": [
+      "Bash(bun run lint)",
+      "Bash(bun run format)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit(*.ts)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run format"
+          },
+          {
+            "type": "command",
+            "command": "bun run lint"
+          },
+          {
+            "type": "command",
+            "command": "bunx tsc"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,15 @@ jobs:
     - name: Install dependencies
       run: bun install
 
+    - name: Run TypeScript type checking
+      run: bun run typecheck
+
+    - name: Check linting
+      run: bun run lint:check
+
+    - name: Check formatting
+      run: bun run format:check
+
     - name: Run tests
       run: bun test
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,11 @@
       "dependencies": {
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^10.2.0",
-        "tsc": "^2.0.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
-        "typescript": "^5",
+        "typescript": "^5.9.2",
       },
     },
   },
@@ -40,9 +39,7 @@
 
     "jsonpath-plus": ["jsonpath-plus@10.3.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA=="],
 
-    "tsc": ["tsc@2.0.4", "", { "bin": { "tsc": "bin/tsc" } }, "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q=="],
-
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
 		"test:unit": "bun test --ignore cli.test.ts",
 		"build": "bun build ./src/cli.ts --compile --outfile kzdiff",
 		"format": "biome format --write",
+		"format:check": "biome format",
 		"lint": "biome lint --fix",
+		"lint:check": "biome lint",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
 	},
 	"dependencies": {
 		"js-yaml": "^4.1.0",
-		"jsonpath-plus": "^10.2.0",
-		"tsc": "^2.0.4"
+		"jsonpath-plus": "^10.2.0"
 	},
 	"devDependencies": {
 		"@types/bun": "latest",
-		"@types/js-yaml": "^4.0.9"
+		"@types/js-yaml": "^4.0.9",
+		"typescript": "^5.9.2"
 	}
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { $ } from "bun";
-import { join } from "path";
+import { join } from "node:path";
 
 describe("kzdiff CLI", () => {
 	const CLI_PATH = join(process.cwd(), "src/cli.ts");
@@ -213,7 +213,7 @@ describe("kzdiff CLI", () => {
 
 	describe("Debug output", () => {
 		test("should show debug output when verbose flag is set", async () => {
-			const { stdout, stderr } = await runCLI([
+			const { stdout } = await runCLI([
 				EXAMPLE_PATH,
 				"-r",
 				TEST_COMMIT,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -213,12 +213,7 @@ describe("kzdiff CLI", () => {
 
 	describe("Debug output", () => {
 		test("should show debug output when verbose flag is set", async () => {
-			const { stdout } = await runCLI([
-				EXAMPLE_PATH,
-				"-r",
-				TEST_COMMIT,
-				"-v",
-			]);
+			const { stdout } = await runCLI([EXAMPLE_PATH, "-r", TEST_COMMIT, "-v"]);
 
 			// Debug output should be in stdout
 			expect(stdout).toContain("[kzdiff-cli]");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,8 +82,8 @@ Note: When using commit hashes, use the full 40-character SHA`;
 			args[i] === "-r" ||
 			args[i] === "--ref"
 		) {
-			if (i + 1 < args.length && args[i + 1]) {
-				remoteRef = args[i + 1];
+			if (i + 1 < args.length && args[i + 1] !== undefined) {
+				remoteRef = args[i + 1] ?? null;
 				i++; // Skip next argument
 			} else {
 				console.error(
@@ -92,8 +92,9 @@ Note: When using commit hashes, use the full 40-character SHA`;
 				process.exit(1);
 			}
 		} else if (args[i] === "-f" || args[i] === "--filter") {
-			if (i + 1 < args.length && args[i + 1]) {
-				filterOptions.push(args[i + 1]);
+			const nextArg = args[i + 1];
+			if (i + 1 < args.length && nextArg !== undefined) {
+				filterOptions.push(nextArg);
 				i++; // Skip next argument
 			} else {
 				console.error(`Error: ${args[i]} requires a filter expression`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,6 @@
 import { $ } from "bun";
 import { kustomizeBuildToTmp } from "./kustomize";
 import { createDebugLogger, setVerbose } from "./debug";
-import { showDiff } from "./diff";
 import { filterYaml } from "./filter";
 import { jsonDiff } from "./json-diff";
 import { readFile } from "node:fs/promises";
@@ -69,7 +68,7 @@ Note: When using commit hashes, use the full 40-character SHA`;
 		showHelp(1);
 	}
 
-	const kustomizePath = args[0];
+	const kustomizePath = args[0] as string; // We know args[0] exists after the length check
 	let remoteRef: string | null = null;
 	let kustomizeOptions: string[] = [];
 	let verbose = false;
@@ -83,7 +82,7 @@ Note: When using commit hashes, use the full 40-character SHA`;
 			args[i] === "-r" ||
 			args[i] === "--ref"
 		) {
-			if (i + 1 < args.length) {
+			if (i + 1 < args.length && args[i + 1]) {
 				remoteRef = args[i + 1];
 				i++; // Skip next argument
 			} else {
@@ -93,7 +92,7 @@ Note: When using commit hashes, use the full 40-character SHA`;
 				process.exit(1);
 			}
 		} else if (args[i] === "-f" || args[i] === "--filter") {
-			if (i + 1 < args.length) {
+			if (i + 1 < args.length && args[i + 1]) {
 				filterOptions.push(args[i + 1]);
 				i++; // Skip next argument
 			} else {

--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { join } from "path";
-import { tmpdir } from "os";
-import { rm, mkdtemp } from "fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rm, mkdtemp } from "node:fs/promises";
 import { showDiff } from "./diff";
 
 describe("showDiff", () => {
@@ -35,7 +35,7 @@ spec:
 		const originalLog = console.log;
 		let output = "";
 		console.log = (msg: string) => {
-			output += msg + "\n";
+			output += `${msg}\n`;
 		};
 
 		try {
@@ -70,7 +70,7 @@ spec:
 		const originalLog = console.log;
 		let output = "";
 		console.log = (msg: string) => {
-			output += msg + "\n";
+			output += `${msg}\n`;
 		};
 
 		try {
@@ -93,7 +93,7 @@ spec:
 		const originalLog = console.log;
 		let output = "";
 		console.log = (msg: string) => {
-			output += msg + "\n";
+			output += `${msg}\n`;
 		};
 
 		try {
@@ -114,12 +114,12 @@ spec:
 		const originalLog = console.log;
 		const originalDebug = console.debug;
 		let output = "";
-		let debugOutput = "";
+		let _debugOutput = "";
 		console.log = (msg: string) => {
-			output += msg + "\n";
+			output += `${msg}\n`;
 		};
 		console.debug = (msg: string) => {
-			debugOutput += msg + "\n";
+			_debugOutput += `${msg}\n`;
 		};
 
 		try {

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -1,9 +1,22 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { filterYaml } from "./filter";
-import { mkdtemp, rm } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import * as yaml from "js-yaml";
+
+interface K8sResource {
+	kind?: string;
+	metadata?: {
+		name?: string;
+		namespace?: string;
+		labels?: Record<string, string>;
+	};
+	spec?: {
+		replicas?: number;
+		[key: string]: unknown;
+	};
+}
 
 describe("filterYaml", () => {
 	let tempDir: string;
@@ -46,7 +59,7 @@ spec:
 			await filterYaml(testFile, ["kind=Deployment"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as Array<{ kind: string }>;
 
 			expect(docs.length).toBe(2);
 			expect(docs[0].kind).toBe("Deployment");
@@ -80,7 +93,7 @@ spec:
 			await filterYaml(testFile, ["name=app-one"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
 			expect(docs[0].metadata.name).toBe("app-one");
@@ -117,7 +130,7 @@ spec:
 			await filterYaml(testFile, ["namespace=production"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
 			expect(docs[0].metadata.namespace).toBe("production");
@@ -153,10 +166,10 @@ data:
 			await filterYaml(testFile, ["kind=Deployment", "kind=Service"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
-			const kinds = docs.map((d: any) => d.kind).sort();
+			const kinds = docs.map((d) => d.kind).sort();
 			expect(kinds).toEqual(["Deployment", "Service"]);
 		});
 	});
@@ -189,7 +202,7 @@ spec:
 			await filterYaml(testFile, ["$[?(@.spec.replicas>2)]"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
 			expect(docs[0].spec.replicas).toBeGreaterThan(2);
@@ -231,7 +244,7 @@ spec:
 			await filterYaml(testFile, ["$[?(@.metadata.labels.team=='platform')]"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
 			expect(docs[0].metadata.labels.team).toBe("platform");
@@ -282,7 +295,7 @@ metadata:
 			await filterYaml(testFile, []);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			// Content should be unchanged
 			expect(docs.length).toBe(1);
@@ -307,7 +320,7 @@ metadata:
 			await filterYaml(testFile, ["kind=Service"]);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(1);
 			expect(docs[0].kind).toBe("Service");
@@ -329,7 +342,7 @@ metadata:
 			await filterYaml(testFile, ['name="my app deployment"']);
 
 			const filtered = await Bun.file(testFile).text();
-			const docs = yaml.loadAll(filtered);
+			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(1);
 			expect(docs[0].metadata.name).toBe("my app deployment");

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -62,8 +62,8 @@ spec:
 			const docs = yaml.loadAll(filtered) as Array<{ kind: string }>;
 
 			expect(docs.length).toBe(2);
-			expect(docs[0].kind).toBe("Deployment");
-			expect(docs[1].kind).toBe("Deployment");
+			expect(docs[0]?.kind).toBe("Deployment");
+			expect(docs[1]?.kind).toBe("Deployment");
 		});
 
 		test("should filter by metadata.name", async () => {
@@ -96,8 +96,8 @@ spec:
 			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
-			expect(docs[0].metadata.name).toBe("app-one");
-			expect(docs[1].metadata.name).toBe("app-one");
+			expect(docs[0]?.metadata?.name).toBe("app-one");
+			expect(docs[1]?.metadata?.name).toBe("app-one");
 		});
 
 		test("should filter by namespace", async () => {
@@ -133,8 +133,8 @@ spec:
 			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
-			expect(docs[0].metadata.namespace).toBe("production");
-			expect(docs[1].metadata.namespace).toBe("production");
+			expect(docs[0]?.metadata?.namespace).toBe("production");
+			expect(docs[1]?.metadata?.namespace).toBe("production");
 		});
 	});
 
@@ -205,8 +205,8 @@ spec:
 			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
-			expect(docs[0].spec.replicas).toBeGreaterThan(2);
-			expect(docs[1].spec.replicas).toBeGreaterThan(2);
+			expect(docs[0]?.spec?.replicas).toBeGreaterThan(2);
+			expect(docs[1]?.spec?.replicas).toBeGreaterThan(2);
 		});
 
 		test("should support complex JSONPath with labels", async () => {
@@ -247,8 +247,8 @@ spec:
 			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(2);
-			expect(docs[0].metadata.labels.team).toBe("platform");
-			expect(docs[1].metadata.labels.team).toBe("platform");
+			expect(docs[0]?.metadata?.labels?.team).toBe("platform");
+			expect(docs[1]?.metadata?.labels?.team).toBe("platform");
 		});
 	});
 
@@ -299,7 +299,7 @@ metadata:
 
 			// Content should be unchanged
 			expect(docs.length).toBe(1);
-			expect(docs[0].kind).toBe("Deployment");
+			expect(docs[0]?.kind).toBe("Deployment");
 		});
 	});
 
@@ -323,7 +323,7 @@ metadata:
 			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(1);
-			expect(docs[0].kind).toBe("Service");
+			expect(docs[0]?.kind).toBe("Service");
 		});
 
 		test("should handle values with spaces", async () => {
@@ -345,7 +345,7 @@ metadata:
 			const docs = yaml.loadAll(filtered) as K8sResource[];
 
 			expect(docs.length).toBe(1);
-			expect(docs[0].metadata.name).toBe("my app deployment");
+			expect(docs[0]?.metadata?.name).toBe("my app deployment");
 		});
 	});
 });

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -2,6 +2,20 @@ import { JSONPath } from "jsonpath-plus";
 import * as yaml from "js-yaml";
 import { createDebugLogger } from "./debug";
 
+interface K8sResource {
+	kind?: string;
+	metadata?: {
+		name?: string;
+		namespace?: string;
+		labels?: Record<string, string>;
+	};
+	spec?: {
+		replicas?: number;
+		[key: string]: unknown;
+	};
+	[key: string]: unknown;
+}
+
 const debug = createDebugLogger("filter");
 
 export async function filterYaml(
@@ -31,7 +45,7 @@ export async function filterYaml(
 		debug(`Converted filters to JSONPath: ${jsonPathFilters.join(", ")}`);
 
 		// Filter documents
-		const filteredDocuments: any[] = [];
+		const filteredDocuments: K8sResource[] = [];
 		for (const doc of documents) {
 			if (matchesAnyFilter(doc, jsonPathFilters)) {
 				filteredDocuments.push(doc);
@@ -66,9 +80,9 @@ function convertToJsonPath(filter: string): string {
 
 	// Parse simple filter expressions
 	const equalMatch = filter.match(/^(\w+)=(.+)$/);
-	if (equalMatch) {
+	if (equalMatch?.[2]) {
 		const [, key, value] = equalMatch;
-		const quotedValue = value.startsWith('"') ? value : `'${value}'`;
+		const quotedValue = value?.startsWith('"') ? value : `'${value}'`;
 
 		// Convert common shortcuts to JSONPath
 		switch (key) {
@@ -89,7 +103,7 @@ function convertToJsonPath(filter: string): string {
 	return filter;
 }
 
-function matchesAnyFilter(doc: any, jsonPathFilters: string[]): boolean {
+function matchesAnyFilter(doc: K8sResource, jsonPathFilters: string[]): boolean {
 	if (!doc || typeof doc !== "object") {
 		return false;
 	}

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -47,8 +47,9 @@ export async function filterYaml(
 		// Filter documents
 		const filteredDocuments: K8sResource[] = [];
 		for (const doc of documents) {
-			if (matchesAnyFilter(doc, jsonPathFilters)) {
-				filteredDocuments.push(doc);
+			const resource = doc as K8sResource;
+			if (matchesAnyFilter(resource, jsonPathFilters)) {
+				filteredDocuments.push(resource);
 			}
 		}
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -104,7 +104,10 @@ function convertToJsonPath(filter: string): string {
 	return filter;
 }
 
-function matchesAnyFilter(doc: K8sResource, jsonPathFilters: string[]): boolean {
+function matchesAnyFilter(
+	doc: K8sResource,
+	jsonPathFilters: string[],
+): boolean {
 	if (!doc || typeof doc !== "object") {
 		return false;
 	}

--- a/src/json-diff.ts
+++ b/src/json-diff.ts
@@ -244,7 +244,7 @@ function shouldGroupTogether(
 	// Get the paths
 	const lastDiff = currentGroup[currentGroup.length - 1];
 	if (!lastDiff) return false;
-	
+
 	const lastParts = lastDiff.path.split(".");
 	const newParts = newDiff.path.split(".");
 
@@ -308,7 +308,7 @@ function findOptimalBasePath(paths: string[]): string {
 	const commonParts: string[] = [];
 	const firstPath = splitPaths[0];
 	if (!firstPath) return "";
-	
+
 	for (let i = 0; i < minLength; i++) {
 		const part = firstPath[i];
 		if (part && splitPaths.every((p) => p[i] === part)) {
@@ -364,7 +364,7 @@ function formatGroupedDiff(group: DiffGroup): string {
 		for (let i = 0; i < parts.length; i++) {
 			const part = parts[i];
 			if (!part) continue;
-			
+
 			if (!current.children.has(part)) {
 				current.children.set(part, {
 					path: parts.slice(0, i + 1).join("."),

--- a/src/kustomize.test.ts
+++ b/src/kustomize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { stat } from "fs/promises";
-import { join } from "path";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
 import { kustomizeBuildToTmp } from "./kustomize";
 import { $ } from "bun";
 

--- a/src/kustomize.ts
+++ b/src/kustomize.ts
@@ -1,8 +1,12 @@
 import { $ } from "bun";
-import { mkdtemp } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createDebugLogger } from "./debug";
+
+interface ErrorWithStderr extends Error {
+	stderr?: string | Buffer;
+}
 
 interface BuildOptions {
 	ref?: string;
@@ -65,22 +69,25 @@ export async function kustomizeBuildToTmp(
 		);
 
 		return outputPath;
-	} catch (error: any) {
+	} catch (error) {
 		// Check if this is a remote build and the directory doesn't exist
-		if (buildOptions?.remote && error.stderr) {
-			const errorMessage = error.stderr.toString().toLowerCase();
-			const notFoundPatterns = ["does not exist", "no such file or directory"];
+		if (buildOptions?.remote && error instanceof Error && 'stderr' in error) {
+			const errorWithStderr = error as ErrorWithStderr;
+			if (errorWithStderr.stderr) {
+				const errorMessage = errorWithStderr.stderr.toString().toLowerCase();
+				const notFoundPatterns = ["does not exist", "no such file or directory"];
 
-			const isNotFound = notFoundPatterns.some((pattern) =>
-				errorMessage.includes(pattern),
-			);
-
-			if (isNotFound) {
-				debug(
-					`Remote directory not found, creating empty file at ${outputPath}`,
+				const isNotFound = notFoundPatterns.some((pattern) =>
+					errorMessage.includes(pattern),
 				);
-				await Bun.write(outputPath, "");
-				return outputPath;
+
+				if (isNotFound) {
+					debug(
+						`Remote directory not found, creating empty file at ${outputPath}`,
+					);
+					await Bun.write(outputPath, "");
+					return outputPath;
+				}
 			}
 		}
 

--- a/src/kustomize.ts
+++ b/src/kustomize.ts
@@ -92,8 +92,11 @@ export async function kustomizeBuildToTmp(
 		}
 
 		console.error(`[kustomizeBuildToTmp] Error: ${error}`);
-		if (error.stderr) {
-			console.error(`[kustomizeBuildToTmp] stderr: ${error.stderr}`);
+		if (error instanceof Error && 'stderr' in error) {
+			const errorWithStderr = error as ErrorWithStderr;
+			if (errorWithStderr.stderr) {
+				console.error(`[kustomizeBuildToTmp] stderr: ${errorWithStderr.stderr}`);
+			}
 		}
 		throw new Error(`Failed to run kustomize build: ${error}`);
 	}

--- a/src/kustomize.ts
+++ b/src/kustomize.ts
@@ -71,11 +71,14 @@ export async function kustomizeBuildToTmp(
 		return outputPath;
 	} catch (error) {
 		// Check if this is a remote build and the directory doesn't exist
-		if (buildOptions?.remote && error instanceof Error && 'stderr' in error) {
+		if (buildOptions?.remote && error instanceof Error && "stderr" in error) {
 			const errorWithStderr = error as ErrorWithStderr;
 			if (errorWithStderr.stderr) {
 				const errorMessage = errorWithStderr.stderr.toString().toLowerCase();
-				const notFoundPatterns = ["does not exist", "no such file or directory"];
+				const notFoundPatterns = [
+					"does not exist",
+					"no such file or directory",
+				];
 
 				const isNotFound = notFoundPatterns.some((pattern) =>
 					errorMessage.includes(pattern),
@@ -92,10 +95,12 @@ export async function kustomizeBuildToTmp(
 		}
 
 		console.error(`[kustomizeBuildToTmp] Error: ${error}`);
-		if (error instanceof Error && 'stderr' in error) {
+		if (error instanceof Error && "stderr" in error) {
 			const errorWithStderr = error as ErrorWithStderr;
 			if (errorWithStderr.stderr) {
-				console.error(`[kustomizeBuildToTmp] stderr: ${errorWithStderr.stderr}`);
+				console.error(
+					`[kustomizeBuildToTmp] stderr: ${errorWithStderr.stderr}`,
+				);
 			}
 		}
 		throw new Error(`Failed to run kustomize build: ${error}`);


### PR DESCRIPTION
## Summary
- Add TypeScript type checking, linting, and formatting checks to CI workflow
- Fix all existing TypeScript errors and lint warnings
- Ensure CI fails on any code quality issues

## Changes
### CI Pipeline Enhancements
- Added TypeScript type checking step
- Added linting check step (without auto-fix)
- Added formatting check step (without auto-fix)
- Created CI-specific check commands in package.json

### Code Quality Fixes
- Fixed Node.js import protocol warnings (added `node:` prefix)
- Fixed TypeScript type errors across multiple files
- Replaced string concatenation with template literals
- Removed unused variables and imports
- Improved type safety by replacing `any` types with proper interfaces

## Test Plan
- [x] Run `bun run typecheck` - passes without errors
- [x] Run `bun run lint:check` - passes without warnings
- [x] Run `bun run format:check` - no formatting issues
- [x] Run `bun test` - all tests pass
- [x] CI workflow executes all checks before running tests