### PR TITLE
feat: support short commit hashes

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -6,6 +6,7 @@ describe("kzdiff CLI", () => {
 	const CLI_PATH = join(process.cwd(), "src/cli.ts")
 	const TEST_COMMIT = "3b4d8b0121ac84d7678591d8139b6eb5f88061d6"
 	const EXAMPLE_PATH = "./examples/overlays/prod"
+	const SHORT_TEST_COMMIT = TEST_COMMIT.slice(0, 7)
 
 	// Helper to run CLI and capture output
 	async function runCLI(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
@@ -64,6 +65,16 @@ describe("kzdiff CLI", () => {
 
 			// Current version has additional team label that doesn't exist in test commit
 			expect(stdout).toContain("team: platform")
+		})
+
+		test("should resolve short commit hashes", async () => {
+			const { stdout, exitCode } = await runCLI([EXAMPLE_PATH, "-r", SHORT_TEST_COMMIT, "-v"])
+
+			expect(exitCode).toBe(0)
+			expect(stdout).toContain("Building local version...")
+			expect(stdout).toContain(`Resolved short commit ${SHORT_TEST_COMMIT} to full SHA ${TEST_COMMIT}`)
+			expect(stdout).toContain(`Building remote version (${TEST_COMMIT})...`)
+			expect(stdout).toContain(`Showing diff between ${TEST_COMMIT} and local changes:`)
 		})
 
 		test("should compare with branch name", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ Examples:
   ${progName} ./examples/overlays/prod -- --enable-helm
   ${progName} ./examples/overlays/prod -b staging -- --enable-helm
 
-Note: When using commit hashes, use the full 40-character SHA`
+Note: Short commit hashes are supported and will be resolved automatically`
 
 		console.log(helpText)
 		process.exit(exitCode)
@@ -157,6 +157,39 @@ Note: When using commit hashes, use the full 40-character SHA`
 				if (!remoteRef) {
 					console.error("Could not determine default remote branch. Please specify with -b or -r option.")
 					process.exit(1)
+				}
+			}
+		}
+
+		if (remoteRef) {
+			const potentialShaPattern = /^[0-9a-fA-F]{7,40}$/
+			const isPotentialSha = potentialShaPattern.test(remoteRef)
+
+			if (isPotentialSha && remoteRef.length < 40) {
+				const branchCheck = await $`git show-ref --verify --quiet refs/heads/${remoteRef}`.quiet().nothrow()
+				const tagCheck = await $`git show-ref --verify --quiet refs/tags/${remoteRef}`.quiet().nothrow()
+
+				if (branchCheck.exitCode !== 0 && tagCheck.exitCode !== 0) {
+					const resolvedRef = await $`git rev-parse ${remoteRef}`.quiet().nothrow()
+
+					if (resolvedRef.exitCode === 0) {
+						const fullSha = resolvedRef.stdout.toString().trim()
+
+						if (fullSha.length === 40) {
+							debug(`Resolved short commit ${remoteRef} to full SHA ${fullSha}`)
+							remoteRef = fullSha
+						} else {
+							debug(`Resolved ref ${remoteRef} to ${fullSha}, but it is not a full 40-character SHA.`)
+						}
+					} else {
+						const errorMessage = resolvedRef.stderr?.toString().trim()
+
+						if (errorMessage) {
+							debug(`Failed to resolve short commit ${remoteRef}: ${errorMessage}`)
+						} else {
+							debug(`Failed to resolve short commit ${remoteRef}: exit code ${resolvedRef.exitCode}`)
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- resolve short Git commit hashes to their full SHA before running kustomize
- log the resolution in verbose mode and document support in the CLI help text
- add a CLI test that verifies short hashes work end to end

## Testing
- bun run format
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ca03a8d1c483208a7dc14952c089c4