### PR TITLE
feat: 短いコミットハッシュの解決機能を追加

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,11 +2,11 @@ import { describe, test, expect, beforeEach } from "bun:test"
 import { $ } from "bun"
 import { join } from "node:path"
 
-	describe("kzdiff CLI", () => {
-		const CLI_PATH = join(process.cwd(), "src/cli.ts")
-		const TEST_COMMIT = "3b4d8b0121ac84d7678591d8139b6eb5f88061d6"
-		const TEST_COMMIT_SHORT = TEST_COMMIT.slice(0, 8)
-		const EXAMPLE_PATH = "./examples/overlays/prod"
+describe("kzdiff CLI", () => {
+	const CLI_PATH = join(process.cwd(), "src/cli.ts")
+	const TEST_COMMIT = "3b4d8b0121ac84d7678591d8139b6eb5f88061d6"
+	const TEST_COMMIT_SHORT = TEST_COMMIT.slice(0, 8)
+	const EXAMPLE_PATH = "./examples/overlays/prod"
 
 	// Helper to run CLI and capture output
 	async function runCLI(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,10 +2,11 @@ import { describe, test, expect, beforeEach } from "bun:test"
 import { $ } from "bun"
 import { join } from "node:path"
 
-describe("kzdiff CLI", () => {
-	const CLI_PATH = join(process.cwd(), "src/cli.ts")
-	const TEST_COMMIT = "3b4d8b0121ac84d7678591d8139b6eb5f88061d6"
-	const EXAMPLE_PATH = "./examples/overlays/prod"
+	describe("kzdiff CLI", () => {
+		const CLI_PATH = join(process.cwd(), "src/cli.ts")
+		const TEST_COMMIT = "3b4d8b0121ac84d7678591d8139b6eb5f88061d6"
+		const TEST_COMMIT_SHORT = TEST_COMMIT.slice(0, 8)
+		const EXAMPLE_PATH = "./examples/overlays/prod"
 
 	// Helper to run CLI and capture output
 	async function runCLI(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
@@ -64,6 +65,16 @@ describe("kzdiff CLI", () => {
 
 			// Current version has additional team label that doesn't exist in test commit
 			expect(stdout).toContain("team: platform")
+		})
+
+		test("should resolve short commit hash", async () => {
+			const { stdout, exitCode } = await runCLI([EXAMPLE_PATH, "-r", TEST_COMMIT_SHORT, "-v"])
+
+			expect(exitCode).toBe(0)
+			expect(stdout).toContain("Building local version...")
+			expect(stdout).toContain(`Resolved short commit hash ${TEST_COMMIT_SHORT} to ${TEST_COMMIT}`)
+			expect(stdout).toContain(`Building remote version (${TEST_COMMIT_SHORT} -> ${TEST_COMMIT})...`)
+			expect(stdout).toContain(`Showing diff between ${TEST_COMMIT_SHORT} -> ${TEST_COMMIT} and local changes:`)
 		})
 
 		test("should compare with branch name", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,18 +22,23 @@ async function resolveShortCommit(ref: string, remote: string): Promise<string> 
 		// fall through to remote lookup
 	}
 
-	const pattern = `${ref}*`
-	const lsRemoteOutput = (await $`git ls-remote ${remote} ${pattern}`.nothrow().text()).trim()
+	const lsRemoteOutput = (await $`git ls-remote ${remote}`.nothrow().text()).trim()
 	if (!lsRemoteOutput) {
 		throw new Error(`Could not resolve short commit hash '${ref}' on remote`)
 	}
 
-	const matches = lsRemoteOutput
-		.split("\n")
-		.map((line) => line.trim())
-		.filter(Boolean)
-		.map((line) => line.split(/\s+/)[0] ?? "")
-		.filter((sha) => FULL_SHA_REGEX.test(sha))
+	const lowercaseRef = ref.toLowerCase()
+	const matches = Array.from(
+		new Set(
+			lsRemoteOutput
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(Boolean)
+				.map((line) => line.split(/\s+/)[0] ?? "")
+				.filter((sha) => FULL_SHA_REGEX.test(sha))
+				.filter((sha) => sha.toLowerCase().startsWith(lowercaseRef)),
+		),
+	)
 
 	if (matches.length === 1) {
 		return matches[0]!

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,9 +218,8 @@ Note: Commit hashes can be full 40-character SHAs or short (>=7 chars) identifie
 			}
 		}
 
-		const remoteRefLabel = remoteRefInput && remoteRefInput !== remoteRef
-			? `${remoteRefInput} -> ${remoteRef}`
-			: remoteRef
+		const remoteRefLabel =
+			remoteRefInput && remoteRefInput !== remoteRef ? `${remoteRefInput} -> ${remoteRef}` : remoteRef
 
 		debug(`Using remote ref: ${remoteRefLabel}`)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,43 @@ import { yamlDiff } from "./yaml-diff"
 
 const debug = createDebugLogger("kzdiff-cli")
 
+const SHORT_SHA_REGEX = /^[0-9a-fA-F]{7,39}$/
+const FULL_SHA_REGEX = /^[0-9a-fA-F]{40}$/
+
+async function resolveShortCommit(ref: string, remote: string): Promise<string> {
+	try {
+		const resolved = (await $`git rev-parse --verify ${ref}^{commit}`.text()).trim()
+		if (FULL_SHA_REGEX.test(resolved)) {
+			return resolved
+		}
+	} catch {
+		// fall through to remote lookup
+	}
+
+	const pattern = `${ref}*`
+	const lsRemoteOutput = (await $`git ls-remote ${remote} ${pattern}`.nothrow().text()).trim()
+	if (!lsRemoteOutput) {
+		throw new Error(`Could not resolve short commit hash '${ref}' on remote`)
+	}
+
+	const matches = lsRemoteOutput
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => line.split(/\s+/)[0] ?? "")
+		.filter((sha) => FULL_SHA_REGEX.test(sha))
+
+	if (matches.length === 1) {
+		return matches[0]!
+	}
+
+	if (matches.length === 0) {
+		throw new Error(`Could not resolve short commit hash '${ref}' on remote`)
+	}
+
+	throw new Error(`Short commit hash '${ref}' is ambiguous on remote`)
+}
+
 async function main() {
 	const args = process.argv.slice(2)
 
@@ -46,7 +83,7 @@ Examples:
   ${progName} ./examples/overlays/prod -- --enable-helm
   ${progName} ./examples/overlays/prod -b staging -- --enable-helm
 
-Note: When using commit hashes, use the full 40-character SHA`
+Note: Commit hashes can be full 40-character SHAs or short (>=7 chars) identifiers`
 
 		console.log(helpText)
 		process.exit(exitCode)
@@ -161,7 +198,26 @@ Note: When using commit hashes, use the full 40-character SHA`
 			}
 		}
 
-		debug(`Using remote ref: ${remoteRef}`)
+		const remoteRefInput = remoteRef
+		if (remoteRef && SHORT_SHA_REGEX.test(remoteRef) && !FULL_SHA_REGEX.test(remoteRef)) {
+			try {
+				const resolvedRef = await resolveShortCommit(remoteRef, remote)
+				if (resolvedRef !== remoteRef) {
+					debug(`Resolved short commit hash ${remoteRef} to ${resolvedRef}`)
+					remoteRef = resolvedRef
+				}
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				console.error(`Error: ${message}`)
+				process.exit(1)
+			}
+		}
+
+		const remoteRefLabel = remoteRefInput && remoteRefInput !== remoteRef
+			? `${remoteRefInput} -> ${remoteRef}`
+			: remoteRef
+
+		debug(`Using remote ref: ${remoteRefLabel}`)
 
 		// Build local version
 		debug("Building local version...")
@@ -169,7 +225,7 @@ Note: When using commit hashes, use the full 40-character SHA`
 		debug(`Local build saved to: ${localPath}`)
 
 		// Build remote version (from specified ref)
-		debug(`Building remote version (${remoteRef})...`)
+		debug(`Building remote version (${remoteRefLabel})...`)
 		const remotePath = await kustomizeBuildToTmp(kustomizePath, "before.yaml", kustomizeOptions, {
 			ref: remoteRef,
 			remote,
@@ -185,7 +241,7 @@ Note: When using commit hashes, use the full 40-character SHA`
 		}
 
 		// Show diff
-		debug(`\nShowing diff between ${remoteRef} and local changes:`)
+		debug(`\nShowing diff between ${remoteRefLabel} and local changes:`)
 		debug("=".repeat(80))
 
 		// Use YAML-based diff for better structured output


### PR DESCRIPTION
## Summary
- Add support for resolving short commit hashes (>=7 characters) in the CLI
- Implement automatic resolution through git rev-parse and git ls-remote 
- Update CLI tests to validate short hash resolution functionality

## Problem
Previously, kzdiff required full 40-character SHA hashes when comparing with specific commits. This was inconvenient for users who wanted to use shorter, more readable commit identifiers.

## Solution
Implemented a `resolveShortCommit` function that:
1. First attempts to resolve the short hash locally using `git rev-parse`
2. Falls back to remote lookup using `git ls-remote` with pattern matching
3. Handles ambiguous matches with clear error messages

## Changes
- **src/cli.ts**: Added short hash resolution logic with proper validation
- **src/cli.test.ts**: Added test case for short commit hash functionality
- Updated help text to mention support for short commit identifiers

## Test Plan
- [x] Run `bun test` - all tests pass
- [x] Run `bun run format` - code is properly formatted  
- [x] Run `bun run lint` - no linting issues
- [x] Run `bun run typecheck` - no type errors
- [x] Manual testing with short hashes (7-39 chars)
- [x] Verified error handling for ambiguous hashes

## Breaking Changes
None - this is a backwards-compatible enhancement

## Additional Notes
NA